### PR TITLE
Correct typo of "PRIORITY" in the template

### DIFF
--- a/management/templates/custom-dns.html
+++ b/management/templates/custom-dns.html
@@ -35,8 +35,8 @@
         <option value="AAAA" data-hint="Enter an IPv6 address.">AAAA (IPv6 address)</option>
         <option value="CNAME" data-hint="Enter another domain name followed by a period at the end (e.g. mypage.github.io.).">CNAME (DNS forwarding)</option>
         <option value="TXT" data-hint="Enter arbitrary text.">TXT (text record)</option>
-        <option value="MX" data-hint="Enter record in the form of PRIORIY DOMAIN., including trailing period (e.g. 20 mx.example.com.).">MX (mail exchanger)</option>
-        <option value="SRV" data-hint="Enter record in the form of PRIORIY WEIGHT PORT TARGET., including trailing period (e.g. 10 10 5060 sip.example.com.).">SRV (service record)</option>
+        <option value="MX" data-hint="Enter record in the form of PRIORITY DOMAIN., including trailing period (e.g. 20 mx.example.com.).">MX (mail exchanger)</option>
+        <option value="SRV" data-hint="Enter record in the form of PRIORITY WEIGHT PORT TARGET., including trailing period (e.g. 10 10 5060 sip.example.com.).">SRV (service record)</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
Corrected typo of the word "PRIORITY" in the template
